### PR TITLE
fix: restore compatibility with Plasma < 6.6

### DIFF
--- a/plasmoid/contents/ui/ConnectionItem.qml
+++ b/plasmoid/contents/ui/ConnectionItem.qml
@@ -10,11 +10,9 @@ import org.kde.kirigami as Kirigami
 import "../code/globals.js" as Globals
 
 PlasmaExtras.ExpandableListItem {
-    required index
-    required property var model
     property var connectionObject: ({})
     readonly property var connectionItemModel: model
-
+    index: model.index
     title: model.title
     subtitle: model.subtitle
     icon: resolveIcon(model.icon)


### PR DESCRIPTION
The previous fix for the Plasma 6.6+ scroll glitch introduced a crash on earlier Plasma versions.

Closes #49